### PR TITLE
centre align thermometer for small screens

### DIFF
--- a/src/pages/components/SupportUs.js
+++ b/src/pages/components/SupportUs.js
@@ -95,7 +95,7 @@ export default function SupportUs() {
                         </div>
                     </div>
                 </Grid>
-                <Grid item sm={12} md={6}>
+                <Grid item xs={12} md={6}>
                     <Box sx={{ display: "flex", justifyContent: "center" }}>
                         <img style={{ maxWidth: "225px" }} src={thermometer} alt="Donation tracker thermometer" />
                     </Box>


### PR DESCRIPTION
Context:

Fixed bug where thermometer image in Support Us would snap to the left when screen size was smaller than 600px.

Screenshots:
![image](https://github.com/Girls-in-Steam/girls-in-steam-official/assets/79772390/f197c4ce-3e87-464f-b91a-dad826783505)
